### PR TITLE
Adds unit tests for LoadMoreButtonContainer

### DIFF
--- a/src/components/LoadMoreButton/LoadMoreButtonContainer.test.tsx
+++ b/src/components/LoadMoreButton/LoadMoreButtonContainer.test.tsx
@@ -1,0 +1,38 @@
+import { mapStateToProps, mapDispatchToProps } from "./LoadMoreButtonContainer";
+import initialState from "../../redux/initialState";
+import { loadMore } from "../../redux/actions";
+
+describe("LoadMoreButtonContsiner", () => {
+  it("is hidden when next page url is undefined", () => {
+    var sut = mapStateToProps;
+
+    var result = sut({ ...initialState, nextPageUrl: undefined });
+
+    expect(result.hidden).toBeTruthy();
+  });
+
+  it("is hidden when nextPageUrl is an empty string", () => {
+    var sut = mapStateToProps;
+
+    var result = sut({ ...initialState, nextPageUrl: "" });
+
+    expect(result.hidden).toBeTruthy();
+  });
+
+  it("is shown when nextPageUrl is populated", () => {
+    var sut = mapStateToProps;
+
+    var result = sut({ ...initialState, nextPageUrl: "some.fake.url" });
+
+    expect(result.hidden).toBeFalsy();
+  });
+
+  it("onClick is mapped to dispatch load more", () => {
+    let mockDispatch = jest.fn().mockName("dispatch mock");
+    var sut = mapDispatchToProps;
+
+    sut(mockDispatch).onClick();
+
+    expect(mockDispatch.mock.calls[0][0]).toEqual(loadMore());
+  });
+});


### PR DESCRIPTION
This isolates map state and map dispatch to props to verify they do what we want.
Its not perfect as ideally we would test the mounting the component wrapped with a <Provider>,
but this adds a lot of noise and brittleness to the tests.